### PR TITLE
Sort ADR numbers before gap validation

### DIFF
--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -135,6 +136,9 @@ func (v *Validator) validateSequentialNumbering(filenames []string, result *Vali
 			numbers = append(numbers, num)
 		}
 	}
+
+	// Ensure numbers are in order before checking gaps
+	sort.Ints(numbers)
 
 	// Check for gaps in numbering
 	for i := 0; i < len(numbers)-1; i++ {

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -1,0 +1,15 @@
+package validator
+
+import "testing"
+
+func TestValidateSequentialNumberingIgnoresFileOrder(t *testing.T) {
+	v := New(&Config{})
+	filenames := []string{"0002-second.md", "0001-first.md", "0003-third.md"}
+	result := &ValidationResult{}
+	if err := v.validateSequentialNumbering(filenames, result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ErrorCount != 0 {
+		t.Fatalf("expected no errors, got %d: %#v", result.ErrorCount, result.Issues)
+	}
+}


### PR DESCRIPTION
## Summary
- sort ADR numbers before checking for gaps in sequence
- add test ensuring numbering validation ignores file order

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68950bee8c2c83339e51b7ab7ab9ca76